### PR TITLE
Added bundle plugin to create OSGi manifest data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
 
     <groupId>org.easycassandra</groupId>
     <artifactId>EasyCassandra</artifactId>
-    <version>2.0.4-ALPHA</version>
-    <packaging>jar</packaging>
+    <version>2.0.4-SNAPSHOT</version>
+    <packaging>bundle</packaging>
 
 	<properties>
 		<github.maven.repository>file:///home/otaviojava/Ambiente/repositorio/otaviojava/repository/</github.maven.repository>
@@ -34,6 +34,18 @@
 			</plugin>
 
 
+			<plugin>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>maven-bundle-plugin</artifactId>
+			<extensions>true</extensions>
+			<configuration>
+			  <instructions>
+				<Export-Package>org.easycassandra,org.easycassandra.persistence.cassandra</Export-Package>
+				<Import-Package>javax.persistence;version="[2,3)",!javax.persistence,*</Import-Package>
+			  </instructions>
+			</configuration>
+		  </plugin>
+		
 
 		</plugins>
 	</build>


### PR DESCRIPTION
This update adds OSGi metadata to the JAR's manifest (using the bundle maven plugin), allowing EasyCassandra to be deployed in an OSGi container. I've tested this in Apache Karaf. 

The explicit import of javax.persistence is to solve an issue I encountered with BND automatically assuming a version range of < 2.0. Feel free to add more packages to be exported if these are part of the EC's API.

As an aside, I first tried using the Achilles Cassandra ORM layer in an OSGi environment and didn't get very far due to class loading issues caused by its use of Reflections and cglib libraries. I suspect other ORM libs may have similar issues. Whereas EasyCassandra seems to work very well for me.

For anyone else using Apache Karaf, this feature descriptor will be useful:

```
<feature name="easycassandra" version="2.0.4">
    <bundle>mvn:com.codahale.metrics/metrics-core/3.0.2</bundle>
    <bundle>mvn:com.google.guava/guava/16.0.1</bundle>
    <bundle>mvn:io.netty/netty/3.9.0.Final</bundle>
    <bundle>mvn:com.datastax.cassandra/cassandra-driver-core/2.0.1</bundle>
    <bundle>mvn:com.google.code.gson/gson/2.2.4</bundle>
    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-beans/3.2.8.RELEASE_1</bundle>
    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-core/3.2.8.RELEASE_1</bundle>
    <bundle>mvn:org.springframework.data/spring-data-commons-core/1.4.1.RELEASE</bundle>
    <bundle>mvn:org.eclipse.persistence/javax.persistence/2.0.0</bundle>           
    <bundle>mvn:org.easycassandra/EasyCassandra/2.0.4-SNAPSHOT</bundle>
```

</feature>
