### PR TITLE
Bug Fix in between clause and @PartKey and @ClusteringOrder annotation 

### DIFF
--- a/src/main/java/org/easycassandra/ClusteringOrder.java
+++ b/src/main/java/org/easycassandra/ClusteringOrder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Gustavo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.easycassandra;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The field with this annotation is used to ordering in clusters. The field need to be part of primary key and not part
+ * of partition key.
+ *
+ * @author Gustavo Leitão
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClusteringOrder {
+
+    Order order() default Order.ASC;
+
+}

--- a/src/main/java/org/easycassandra/ColumnUtil.java
+++ b/src/main/java/org/easycassandra/ColumnUtil.java
@@ -339,6 +339,39 @@ enum ColumnUtil {
     }
 
     /**
+     * verify if this is a Partkey id column.
+     * @param field the field
+     * @return if has PartKey annotation
+     */
+    public boolean isPartkeyField(Field field) {
+        return field.getAnnotation(Partkey.class) != null;
+    }
+
+    /**
+     * verify is this field is Cluester Ordering column.
+     *
+     * @param field the field
+     * @return if has ClusteringOrder annotation
+     */
+    public boolean isClusteringOrderField(Field field) {
+        return field.getAnnotation(ClusteringOrder.class) != null;
+    }
+
+    /**
+     * Retrieve the cluster order.
+     *
+     * @param field the field
+     * @return The instance of Order that indicates the order
+     */
+    public Order getClusterOrder(Field field) {
+        Order order = null;
+        if (isClusteringOrderField(field)) {
+            order = field.getAnnotation(ClusteringOrder.class).order();
+        }
+        return order;
+    }
+
+    /**
      * verify if this is a Version column.
      * @param field the field
      * @return if has Version annotation

--- a/src/main/java/org/easycassandra/ColumnUtil.java
+++ b/src/main/java/org/easycassandra/ColumnUtil.java
@@ -328,16 +328,7 @@ enum ColumnUtil {
     public boolean isEmbeddedField(Field field) {
         return field.getAnnotation(Embedded.class) != null;
     }
-
-    /**
-     * verify if this is a Embedded id column.
-     * @param field the field
-     * @return if has EmbeddedId annotation
-     */
-    public boolean isEmbeddedIdField(Field field) {
-        return field.getAnnotation(EmbeddedId.class) != null;
-    }
-
+    
     /**
      * verify if this is a Partkey id column.
      * @param field the field
@@ -346,7 +337,7 @@ enum ColumnUtil {
     public boolean isPartkeyField(Field field) {
         return field.getAnnotation(Partkey.class) != null;
     }
-
+    
     /**
      * verify is this field is Cluester Ordering column.
      *
@@ -356,7 +347,7 @@ enum ColumnUtil {
     public boolean isClusteringOrderField(Field field) {
         return field.getAnnotation(ClusteringOrder.class) != null;
     }
-
+    
     /**
      * Retrieve the cluster order.
      *
@@ -369,6 +360,15 @@ enum ColumnUtil {
             order = field.getAnnotation(ClusteringOrder.class).order();
         }
         return order;
+    }    
+
+    /**
+     * verify if this is a Embedded id column.
+     * @param field the field
+     * @return if has EmbeddedId annotation
+     */
+    public boolean isEmbeddedIdField(Field field) {
+        return field.getAnnotation(EmbeddedId.class) != null;
     }
 
     /**

--- a/src/main/java/org/easycassandra/FieldInformation.java
+++ b/src/main/java/org/easycassandra/FieldInformation.java
@@ -50,6 +50,21 @@ public class FieldInformation implements Comparable<FieldInformation> {
      */
     private boolean keyCheck;
     /**
+     * indicates this field is partkey.
+     */
+    private boolean partkeyCheck;
+
+    /**
+     * indicates if the field is part of ordering cluster.
+     */
+    private boolean clusteringOrderCheck;
+
+    /**
+     * indicates the order
+     */
+    private Order order;
+
+    /**
      * list of information when this field is embedded or embedded Id.
      */
     private ClassInformation subFields;
@@ -114,6 +129,19 @@ public class FieldInformation implements Comparable<FieldInformation> {
     public boolean isKeyCheck() {
         return keyCheck;
     }
+
+    public boolean isPartKeyCheck() {
+        return partkeyCheck;
+    }
+
+    public boolean isClusteringOrderCheck() {
+        return clusteringOrderCheck;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
     /**
      * create the class with field.
      * @param field - field to receive the information
@@ -124,6 +152,13 @@ public class FieldInformation implements Comparable<FieldInformation> {
 
         this.keyCheck = ColumnUtil.INTANCE.isEmbeddedIdField(field)
                 || ColumnUtil.INTANCE.isIdField(field);
+
+        this.partkeyCheck = ColumnUtil.INTANCE.isPartkeyField(field);
+
+        this.clusteringOrderCheck = ColumnUtil.INTANCE.isClusteringOrderField(field);
+
+        this.order = ColumnUtil.INTANCE.getClusterOrder(field);
+
         this.type = FieldType.getTypeByField(field);
         this.field = field;
         this.collectionType = FieldType.EMPTY;

--- a/src/main/java/org/easycassandra/Order.java
+++ b/src/main/java/org/easycassandra/Order.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 Gustavo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.easycassandra;
+
+/**
+ * Options to cluester ordering.
+ *
+ * @author Gustavo Leitão
+ */
+public enum Order {
+
+    ASC, DESC;
+};

--- a/src/main/java/org/easycassandra/Partkey.java
+++ b/src/main/java/org/easycassandra/Partkey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Otávio Gonçalves de Santana (otaviojava)
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.easycassandra;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The field with this annotation is part of partkey. The partkey is part of complex primary key that cassandra uses to
+ * separete data in diferents clusters.
+ *
+ * @author Gustavo Leitão
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Partkey {
+}

--- a/src/main/java/org/easycassandra/persistence/cassandra/SelectBuilderImpl.java
+++ b/src/main/java/org/easycassandra/persistence/cassandra/SelectBuilderImpl.java
@@ -84,19 +84,19 @@ public class SelectBuilderImpl <T> implements SelectBuilder<T> {
     @Override
     public SelectBuilder<T> between(String name, Object startValue,
             Object endValue) {
-        return lte(name, startValue).gt(name, endValue);
+        return gte(name, startValue).lt(name, endValue);
     }
 
     @Override
     public SelectBuilder<T> betweenInclusive(String name, Object startValue,
             Object endValue) {
-        return lte(name, startValue).gte(name, endValue);
+        return gte(name, startValue).lte(name, endValue);
     }
 
     @Override
     public SelectBuilder<T> betweenExclusive(String name, Object startValue,
             Object endValue) {
-        return lt(name, startValue).gt(name, endValue);
+        return gt(name, startValue).lt(name, endValue);
     }
 
     @Override


### PR DESCRIPTION
- Fix the bug in between clause. It was in reverse order.
- Add @ClusterinOrder annotation to permite the user chooses the cluestering order in a composite key
- Add @Partkey annotation to permite the user chooses the partkey column in a composite key
